### PR TITLE
Bugfix/glob with domain

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -504,7 +504,8 @@ class AzureBlobFileSystem(AsyncFileSystem):
                 ops["path"] = ops["host"] + ops["path"]
 
         logger.debug(f"_strip_protocol({path}) = {ops}")
-        return ops["path"]
+        stripped_path = ops["path"].lstrip("/")
+        return stripped_path
 
     @staticmethod
     def _get_kwargs_from_urls(urlpath):

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -600,6 +600,35 @@ def test_glob(storage):
     assert fs.glob("data/missing/*") == []
 
 
+def test_glob_full_uri(storage):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+    assert fs.glob("abfs://account.dfs.core.windows.net/data/**/*.txt") == [
+        "data/root/a/file.txt",
+        "data/root/a1/file1.txt",
+        "data/root/b/file.txt",
+        "data/root/c/file1.txt",
+        "data/root/c/file2.txt",
+        "data/root/d/file_with_metadata.txt",
+        "data/root/e+f/file1.txt",
+        "data/root/e+f/file2.txt",
+        "data/root/rfile.txt",
+    ]
+
+    assert fs.glob("account.dfs.core.windows.net/data/**/*.txt") == [
+        "data/root/a/file.txt",
+        "data/root/a1/file1.txt",
+        "data/root/b/file.txt",
+        "data/root/c/file1.txt",
+        "data/root/c/file2.txt",
+        "data/root/d/file_with_metadata.txt",
+        "data/root/e+f/file1.txt",
+        "data/root/e+f/file2.txt",
+        "data/root/rfile.txt",
+    ]
+
+
 def test_open_file(storage, mocker):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR


### PR DESCRIPTION
When calling glob passing a path like this:

```
abfs://account.dfs.core.windows.net/container/path
# or
account.dfs.core.windows.net/container/path
```

adlfs returns an empty list. However, by debugging the code, I noticed the method
`_strip_domain` was returning `/container/path` instead of `container/path`.

This pr just lstrips the output of the method and adds a test for it